### PR TITLE
feature(rules): remove deprecated no-use-before-declare rule

### DIFF
--- a/src/tslint-rules.json
+++ b/src/tslint-rules.json
@@ -82,7 +82,6 @@
 		"no-trailing-whitespace": true,
 		"no-unused-expression": true,
 		//"no-unused-variable": true,
-		"no-use-before-declare": true,
 		"no-var-keyword": true,
 		"max-classes-per-file": [
 			true,


### PR DESCRIPTION
Notice when running `ng lint`:
<img width="860" alt="Bildschirmfoto 2020-06-23 um 13 59 37" src="https://user-images.githubusercontent.com/26869118/85401376-3808b400-b55a-11ea-808d-03ef5aaffc78.png">

TS-Error:
<img width="956" alt="Bildschirmfoto 2020-06-23 um 14 03 47" src="https://user-images.githubusercontent.com/26869118/85401559-85852100-b55a-11ea-86cd-baf79613345c.png">
