### PR TITLE
Allow exceptions for undefined and null-check on tripple equals rule

### DIFF
--- a/src/tslint-rules.json
+++ b/src/tslint-rules.json
@@ -102,7 +102,7 @@
 		],
 		"radix": true,
 		"semicolon": false,
-		"triple-equals": true,
+		"triple-equals": [true, "allow-undefined-check", "allow-null-check"],
 		"typedef": [
 			true,
 			"call-signature",


### PR DESCRIPTION
With type safety in mind, it's usually a good idea to do strict comparisons `(y === x)`, rather than relying on abstract equality `(y == x)`
however, when checking for `null` or `undefined` we've relied on the deprecated `rsjx` function `isNullOrUndefined()` 
to keep things short and sweet and don't be dependent on workarounds like nullish coalescing `(value ?? false)`
we should allow colleagues to perform abstract comparisons to check for `null` or `undefined`
this makes the code more readable than other methods in my opinion. 
So in the future to check for either `null` or `undefined` at once we can simple do `value != null` or `value != undefined`