### PR TITLE
deleted 'no-trailing-whitespace' rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@plentymarkets/terra-lint-rules",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "custom tslint rules",
 	"main": "index.js",
 	"scripts": {

--- a/src/tslint-rules.json
+++ b/src/tslint-rules.json
@@ -79,7 +79,7 @@
 		"no-shadowed-variable": true,
 		"no-string-literal": false,
 		"no-switch-case-fall-through": true,
-		"no-trailing-whitespace": true,
+		//"no-trailing-whitespace": true,
 		"no-unused-expression": true,
 		//"no-unused-variable": true,
 		"no-var-keyword": true,


### PR DESCRIPTION
this just causes annoyance for devs; trailing whitespaces are removed by prettier in the pre-commit hooks anyways