### PR TITLE
Remove rules covered by prettier

### DIFF
--- a/src/eslint-rules.json
+++ b/src/eslint-rules.json
@@ -81,7 +81,6 @@
 		],
 		"curly": "error",
 		"constructor-super": "error",
-		"eol-last": ["error", "always"],
 		"eqeqeq": [
 			"error",
 			"smart"

--- a/src/eslint-rules.json
+++ b/src/eslint-rules.json
@@ -104,18 +104,6 @@
 			"error",
 			{ "max" : 5 }
 		],
-		"max-len": [
-			"error",
-			{
-				"code": 150,
-				"ignoreComments":  true,
-				"ignoreUrls":  true,
-				"ignoreStrings":  true,
-				"ignoreTemplateLiterals": true,
-				"ignoreRegExpLiterals": true,
-				"ignorePattern": "^import |^export |^interface [a-zA-Z]+ \\{(.*?)\\}|^class [a-zA-Z]+ implements"
-			}
-		],
 		"max-lines": [
 			"error" ,
 			{

--- a/src/eslint-rules.json
+++ b/src/eslint-rules.json
@@ -64,7 +64,6 @@
 		"@typescript-eslint/no-shadow": "error",
 		"no-shadow": "off",
 		"@typescript-eslint/prefer-for-of": "error",
-		"@typescript-eslint/type-annotation-spacing": "error",
 		"@typescript-eslint/typedef": [
 			"error",
 			{

--- a/src/eslint-rules.json
+++ b/src/eslint-rules.json
@@ -150,7 +150,6 @@
 			"rxjs/index",
 			"src/app/**"
 		],
-		"no-trailing-spaces": "error",
 		"no-underscore-dangle": "off",
 		"no-unused-expressions": "error",
 		"no-useless-concat": "error",


### PR DESCRIPTION
@plentymarkets/team-terra
Since prettier takes care of code formatting for us, there is no need to have rules related to style. Consequently it's save to remove them entirely.