### PR TITLE
Restrict deprecated type check imports

### DIFF
--- a/src/eslint-rules.json
+++ b/src/eslint-rules.json
@@ -173,6 +173,16 @@
 		"no-redeclare": "error",
 		"no-restricted-imports": [
 			"error",
+			{ "paths": [{
+				"name": "util",
+				"importNames": ["isNullOrUndefined"],
+				"message": "Please use `value == null` or `value != null` instead."
+			}]},
+			{ "paths": [{
+				"name": "util",
+				"importNames": ["isFunction", "isObject", "isNull", "isUndefined", "isPrimitive", "isString", "isNumber", "isBoolean"],
+				"message": "Please use `typeof value === 'yourType'` instead. Or consult docs for better alternative."
+			}]},
 			"rxjs/internal",
 			"rxjs/index",
 			"src/app/**"


### PR DESCRIPTION
Why?
1. Typescript has typ checking built in. (duh) So it should be check by the compiler
2. It's deprecated for a long time now
3. Since we now can do value == null or value != null using `isNullOrUndefinded` takes up more space
4. Devs can adapt pretty easily