### PR TITLE
Update ReadMe with deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
+# Deprecated
+
+#### This repository is deprecated. It will not be maintained anymore.
+
+---
+
 # terra-lint-rules
 A recommended set of eslint rules for static code analysis of Angular/TypeScript projects.


### PR DESCRIPTION
Since we moved Terra Components to Terra, we no longer need to provide rules for external developers. Hence we decided deprecate it